### PR TITLE
Move current memory value into var

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,7 +42,8 @@ if ARGV[0] == 'up'
   end
 
   if memory.to_i < "8000000000".to_i
-    puts "You need at least 8192MB of memory on your host machine to run this development environment, you only have " + memory.to_i/1000000 + "MB!"
+    current_mem = memory.to_i/1000000
+    puts "You need at least 8192MB of memory on your host machine to run this development environment, you only have #{current_mem} MB!"
     exit
   end
 end


### PR DESCRIPTION
Was failing in the check as it was attempting to add
the string message to the calculate number. Was throwing:
no implicit conversion of Fixnum into String (TypeError)